### PR TITLE
fix: empty value for key map should be skipped to prevent panic

### DIFF
--- a/file/file_test.go
+++ b/file/file_test.go
@@ -169,6 +169,36 @@ meta:
 	assert.Equal(t, expected, element)
 }
 
+func TestDecodeContent_YAML_emptyKey(t *testing.T) {
+	content := `
+name: test
+meta:
+  aaa:
+  - bbb: 1
+  bbb: {"foo":"bar"}
+  null: {"toto":"tata"}
+`
+
+	type Foo struct {
+		Name string
+		Meta map[string]interface{}
+	}
+
+	element := &Foo{}
+
+	err := DecodeContent(content, ".yaml", element)
+	require.NoError(t, err)
+
+	expected := &Foo{
+		Name: "test",
+		Meta: map[string]interface{}{
+			"aaa": []interface{}{map[string]interface{}{"bbb": "1"}},
+			"bbb": map[string]interface{}{"foo": "bar"},
+		},
+	}
+	assert.Equal(t, expected, element)
+}
+
 func TestDecodeContent_JSON(t *testing.T) {
 	content := `
 {

--- a/file/raw_node.go
+++ b/file/raw_node.go
@@ -28,6 +28,9 @@ func decodeRaw(node *parser.Node, vData reflect.Value, filters ...string) error 
 	sortedKeys := sortKeys(vData, filters)
 
 	for _, key := range sortedKeys {
+		if key.Kind() == reflect.Invalid {
+			continue
+		}
 		if vData.MapIndex(key).IsNil() {
 			continue
 		}


### PR DESCRIPTION
When using yaml format, map key can be set to `null` value, resulting to
an empty value. When used in DecodeContent, empty value would trigger a
panic in the MapIndex function.
Let's just skip the invalid key, as we could do if the value is nil.

Current behaviour

```yaml
name: test
meta:
  aaa:
  - bbb: 1
  bbb: {"foo":"bar"}
  null: {"toto":"tata"}
```

Stack trace
```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x17 pc=0x4c29fc]

goroutine 47 [running]:
testing.tRunner.func1.1(0x6c3720, 0x8d7150)
	testing/testing.go:1072 +0x30d
testing.tRunner.func1(0xc0003b9800)
	testing/testing.go:1075 +0x41a
panic(0x6c3720, 0x8d7150)
	runtime/panic.go:969 +0x1b9
reflect.(*rtype).Kind(...)
	reflect/type.go:778
reflect.directlyAssignable(0x6bbca0, 0x0, 0x97)
	reflect/type.go:1571 +0x5c
reflect.Value.assignTo(0x0, 0x0, 0x0, 0x70955f, 0x16, 0x6bbca0, 0x0, 0x6afdc0, 0xc000429050, 0x68d380)
	reflect/value.go:2408 +0x85
reflect.Value.MapIndex(0x6c1280, 0xc00042af90, 0x15, 0x0, 0x0, 0x0, 0xc00040dc20, 0x3, 0x4)
	reflect/value.go:1181 +0xea
github.com/traefik/paerser/file.decodeRaw(0xc000419830, 0x6c1280, 0xc00042af90, 0x15, 0x0, 0x0, 0x0, 0xc000429160, 0x94)
	github.com/traefik/paerser/file/raw_node.go:31 +0x125
github.com/traefik/paerser/file.decodeRaw(0xc0004197a0, 0x6c20c0, 0xc00042aea0, 0x15, 0xc00043a7e0, 0x2, 0x2, 0xc00043a7e0, 0x2)
	github.com/traefik/paerser/file/raw_node.go:96 +0x685
github.com/traefik/paerser/file.decodeRawToNode(0xc00042aea0, 0xc00043a7e0, 0x2, 0x2, 0x2, 0x0, 0x0)
	github.com/traefik/paerser/file/raw_node.go:19 +0xf2
github.com/traefik/paerser/file.DecodeContent(0x714d76, 0x51, 0x703249, 0x5, 0x6a3fe0, 0xc00043a700, 0x15ebbf240dea2, 0x378feb34)
	github.com/traefik/paerser/file/file.go:66 +0x168
github.com/traefik/paerser/file.TestDecodeContent_YAML_emptyKey(0xc0003b9800)
	github.com/traefik/paerser/file/file_test.go:189 +0x7a
testing.tRunner(0xc0003b9800, 0x71a9d8)
	testing/testing.go:1123 +0xef
created by testing.(*T).Run
	testing/testing.go:1168 +0x2b3
```