### PR TITLE
fix: apply time.Second as default unit for integer json unmarshalling

### DIFF
--- a/types/duration.go
+++ b/types/duration.go
@@ -45,7 +45,7 @@ func (d Duration) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON deserializes the given text into a duration value.
 func (d *Duration) UnmarshalJSON(text []byte) error {
 	if v, err := strconv.ParseInt(string(text), 10, 64); err == nil {
-		*d = Duration(time.Duration(v))
+		*d = Duration(time.Duration(v) * time.Second)
 		return nil
 	}
 

--- a/types/duration_test.go
+++ b/types/duration_test.go
@@ -10,25 +10,27 @@ import (
 
 func TestDuration_Set(t *testing.T) {
 	testCases := []struct {
-		desc        string
-		s           string
-		expDuration Duration
-		expErr      bool
+		desc     string
+		value    string
+		assert   require.ErrorAssertionFunc
+		expected Duration
 	}{
 		{
 			desc:   "empty",
-			s:      "",
-			expErr: true,
+			value:  "",
+			assert: require.Error,
 		},
 		{
-			desc:        "duration",
-			s:           "2m",
-			expDuration: Duration(2 * time.Minute),
+			desc:     "duration",
+			value:    "2m",
+			assert:   require.NoError,
+			expected: Duration(2 * time.Minute),
 		},
 		{
-			desc:        "integer",
-			s:           "2",
-			expDuration: Duration(2 * time.Second),
+			desc:     "integer",
+			value:    "2",
+			assert:   require.NoError,
+			expected: Duration(2 * time.Second),
 		},
 	}
 
@@ -36,45 +38,42 @@ func TestDuration_Set(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			var d Duration
 
-			err := d.Set(test.s)
-			if test.expErr {
-				assert.Error(t, err)
-				return
-			}
+			err := d.Set(test.value)
+			test.assert(t, err)
 
-			require.NoError(t, err)
-			assert.Equal(t, test.expDuration, d)
+			assert.Equal(t, test.expected, d)
 		})
 	}
 }
 
 func TestDuration_UnmarshalJSON(t *testing.T) {
 	testCases := []struct {
-		desc        string
-		text        []byte
-		expDuration Duration
-		expErr      bool
+		desc     string
+		text     []byte
+		assert   require.ErrorAssertionFunc
+		expected Duration
 	}{
 		{
 			desc:   "empty",
 			text:   []byte(""),
-			expErr: true,
+			assert: require.Error,
 		},
 		{
-			desc:        "duration",
-			text:        []byte(`"2m"`),
-			expDuration: Duration(2 * time.Minute),
+			desc:     "duration",
+			text:     []byte(`"2m"`),
+			assert:   require.NoError,
+			expected: Duration(2 * time.Minute),
 		},
 		{
-			desc:        "integer",
-			text:        []byte(`2`),
-			expDuration: Duration(2 * time.Second),
+			desc:     "integer",
+			text:     []byte(`2`),
+			assert:   require.NoError,
+			expected: Duration(2 * time.Second),
 		},
-
 		{
 			desc:   "bad format",
 			text:   []byte(`"2"`),
-			expErr: true,
+			assert: require.Error,
 		},
 	}
 
@@ -83,13 +82,9 @@ func TestDuration_UnmarshalJSON(t *testing.T) {
 			var d Duration
 
 			err := d.UnmarshalJSON(test.text)
-			if test.expErr {
-				assert.Error(t, err)
-				return
-			}
+			test.assert(t, err)
 
-			require.NoError(t, err)
-			assert.Equal(t, test.expDuration, d)
+			assert.Equal(t, test.expected, d)
 		})
 	}
 }

--- a/types/duration_test.go
+++ b/types/duration_test.go
@@ -1,0 +1,95 @@
+package types
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDuration_Set(t *testing.T) {
+	testCases := []struct {
+		desc        string
+		s           string
+		expDuration Duration
+		expErr      bool
+	}{
+		{
+			desc:   "empty",
+			s:      "",
+			expErr: true,
+		},
+		{
+			desc:        "duration",
+			s:           "2m",
+			expDuration: Duration(2 * time.Minute),
+		},
+		{
+			desc:        "integer",
+			s:           "2",
+			expDuration: Duration(2 * time.Second),
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			var d Duration
+
+			err := d.Set(test.s)
+			if test.expErr {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, test.expDuration, d)
+		})
+	}
+}
+
+func TestDuration_UnmarshalJSON(t *testing.T) {
+	testCases := []struct {
+		desc        string
+		text        []byte
+		expDuration Duration
+		expErr      bool
+	}{
+		{
+			desc:   "empty",
+			text:   []byte(""),
+			expErr: true,
+		},
+		{
+			desc:        "duration",
+			text:        []byte(`"2m"`),
+			expDuration: Duration(2 * time.Minute),
+		},
+		{
+			desc:        "integer",
+			text:        []byte(`2`),
+			expDuration: Duration(2 * time.Second),
+		},
+
+		{
+			desc:   "bad format",
+			text:   []byte(`"2"`),
+			expErr: true,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			var d Duration
+
+			err := d.UnmarshalJSON(test.text)
+			if test.expErr {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, test.expDuration, d)
+		})
+	}
+}


### PR DESCRIPTION
This PR fixes an issue during the JSON unmarshalling if the data does not define the time unit.

Co-authored-by: kevinpollet <pollet.kevin@gmail.com>