### PR TITLE
fix: bijectivity of JSON marshal and unmarshal

### DIFF
--- a/types/duration.go
+++ b/types/duration.go
@@ -37,9 +37,15 @@ func (d *Duration) UnmarshalText(text []byte) error {
 	return d.Set(string(text))
 }
 
-// MarshalJSON serializes the given duration value.
+// MarshalJSON serializes the given duration value using the quoted version to be compatible with UnmarshalJSON.
 func (d Duration) MarshalJSON() ([]byte, error) {
-	return json.Marshal(time.Duration(d))
+	b, err := json.Marshal(time.Duration(d))
+	if err != nil {
+		return nil, err
+	}
+
+	result := append([]byte(`"`), b...)
+	return append(result, []byte(`ns"`)...), nil
 }
 
 // UnmarshalJSON deserializes the given text into a duration value.

--- a/types/duration.go
+++ b/types/duration.go
@@ -39,14 +39,8 @@ func (d *Duration) UnmarshalText(text []byte) error {
 
 // MarshalJSON serializes the given duration value.
 func (d Duration) MarshalJSON() ([]byte, error) {
-	b, err := json.Marshal(time.Duration(d))
-	if err != nil {
-		return nil, err
-	}
-
-	// quoted to be compatible with UnmarshalJSON
-	result := append([]byte(`"`), b...)
-	return append(result, []byte(`ns"`)...), nil
+	v := time.Duration(time.Duration(d).Nanoseconds())
+	return []byte(`"` + v.String() + `"`), nil
 }
 
 // UnmarshalJSON deserializes the given text into a duration value.

--- a/types/duration.go
+++ b/types/duration.go
@@ -37,13 +37,14 @@ func (d *Duration) UnmarshalText(text []byte) error {
 	return d.Set(string(text))
 }
 
-// MarshalJSON serializes the given duration value using the quoted version to be compatible with UnmarshalJSON.
+// MarshalJSON serializes the given duration value.
 func (d Duration) MarshalJSON() ([]byte, error) {
 	b, err := json.Marshal(time.Duration(d))
 	if err != nil {
 		return nil, err
 	}
 
+	// quoted to be compatible with UnmarshalJSON
 	result := append([]byte(`"`), b...)
 	return append(result, []byte(`ns"`)...), nil
 }
@@ -61,6 +62,7 @@ func (d *Duration) UnmarshalJSON(text []byte) error {
 	if err != nil {
 		return err
 	}
+
 	v, err := time.ParseDuration(value)
 	*d = Duration(v)
 	return err

--- a/types/duration_test.go
+++ b/types/duration_test.go
@@ -46,6 +46,22 @@ func TestDuration_Set(t *testing.T) {
 	}
 }
 
+func TestDuration_MarshalJSON(t *testing.T) {
+	d := Duration(time.Second)
+
+	b, err := d.MarshalJSON()
+	require.NoError(t, err)
+
+	assert.Equal(t, []byte(`"1000000000ns"`), b)
+
+	// Check that marshal value is unmarchable.
+	var ud Duration
+	err = ud.UnmarshalJSON(b)
+	require.NoError(t, err)
+
+	assert.Equal(t, Duration(time.Second), ud)
+}
+
 func TestDuration_UnmarshalJSON(t *testing.T) {
 	testCases := []struct {
 		desc     string

--- a/types/duration_test.go
+++ b/types/duration_test.go
@@ -47,27 +47,75 @@ func TestDuration_Set(t *testing.T) {
 }
 
 func TestDuration_MarshalJSON(t *testing.T) {
-	d := Duration(time.Second)
+	testCases := []struct {
+		desc     string
+		dur      Duration
+		expected []byte
+	}{
+		{
+			desc:     "1 second",
+			dur:      Duration(time.Second),
+			expected: []byte(`"1s"`),
+		},
+		{
+			desc:     "1 millisecond",
+			dur:      Duration(time.Millisecond),
+			expected: []byte(`"1ms"`),
+		},
+		{
+			desc:     "1 nanosecond",
+			dur:      Duration(time.Nanosecond),
+			expected: []byte(`"1ns"`),
+		},
+	}
 
-	b, err := d.MarshalJSON()
-	require.NoError(t, err)
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
 
-	assert.Equal(t, []byte(`"1000000000ns"`), b)
+			b, err := test.dur.MarshalJSON()
+			require.NoError(t, err)
+
+			assert.Equal(t, test.expected, b)
+		})
+	}
 }
 
 func TestDuration_JSON_bijection(t *testing.T) {
-	d := Duration(time.Second)
+	testCases := []struct {
+		desc string
+		dur  Duration
+	}{
+		{
+			desc: "1 second",
+			dur:  Duration(time.Second),
+		},
+		{
+			desc: "1 millisecond",
+			dur:  Duration(time.Millisecond),
+		},
+		{
+			desc: "1 nanosecond",
+			dur:  Duration(time.Nanosecond),
+		},
+	}
 
-	b, err := d.MarshalJSON()
-	require.NoError(t, err)
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
 
-	assert.Equal(t, []byte(`"1000000000ns"`), b)
+			b, err := test.dur.MarshalJSON()
+			require.NoError(t, err)
 
-	var ud Duration
-	err = ud.UnmarshalJSON(b)
-	require.NoError(t, err)
+			var ud Duration
+			err = ud.UnmarshalJSON(b)
+			require.NoError(t, err)
 
-	assert.Equal(t, d, ud)
+			assert.Equal(t, test.dur, ud)
+		})
+	}
 }
 
 func TestDuration_UnmarshalJSON(t *testing.T) {

--- a/types/duration_test.go
+++ b/types/duration_test.go
@@ -53,13 +53,21 @@ func TestDuration_MarshalJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, []byte(`"1000000000ns"`), b)
+}
 
-	// Check that marshal value is unmarchable.
+func TestDuration_JSON_bijection(t *testing.T) {
+	d := Duration(time.Second)
+
+	b, err := d.MarshalJSON()
+	require.NoError(t, err)
+
+	assert.Equal(t, []byte(`"1000000000ns"`), b)
+
 	var ud Duration
 	err = ud.UnmarshalJSON(b)
 	require.NoError(t, err)
 
-	assert.Equal(t, Duration(time.Second), ud)
+	assert.Equal(t, d, ud)
 }
 
 func TestDuration_UnmarshalJSON(t *testing.T) {


### PR DESCRIPTION
Since `UnmarshalJSON` uses `time.Second `by default and `MarshJSON` returns nanosecond, which makes this method incompatible.

This PR fixes this issue by making `MarshalJSON` returns the quoted value.

Co-authored-by: Ludovic Fernandez <ldez@users.noreply.github.com>