### PR TITLE
fix: ignore tag for label decoding

### DIFF
--- a/parser/element_fill.go
+++ b/parser/element_fill.go
@@ -47,7 +47,7 @@ func (f filler) Fill(element interface{}, node *Node) error {
 }
 
 func (f filler) fill(field reflect.Value, node *Node) error {
-	// related to allow-empty tag
+	// related to allow-empty or ignore tag
 	if node.Disabled {
 		return nil
 	}

--- a/parser/element_fill_test.go
+++ b/parser/element_fill_test.go
@@ -735,6 +735,31 @@ func TestFill(t *testing.T) {
 			},
 		},
 		{
+			desc: "empty map",
+			node: &Node{
+				Name: "traefik",
+				Kind: reflect.Struct,
+				Children: []*Node{
+					{
+						Name:      "Foo",
+						FieldName: "Foo",
+						Kind:      reflect.Map,
+						Children:  []*Node{},
+					},
+				},
+			},
+			element: &struct {
+				Foo map[string]string
+			}{},
+			expected: expected{
+				element: &struct {
+					Foo map[string]string
+				}{
+					Foo: map[string]string{},
+				},
+			},
+		},
+		{
 			desc: "slice string",
 			node: &Node{
 				Name: "traefik",

--- a/parser/element_nodes_test.go
+++ b/parser/element_nodes_test.go
@@ -457,6 +457,15 @@ func TestEncodeToNode(t *testing.T) {
 			expected: expected{node: &Node{Name: "traefik"}},
 		},
 		{
+			desc: "ignore map",
+			element: struct {
+				Bar map[string]string `label:"-"`
+			}{
+				Bar: map[string]string{"huu": "hii"},
+			},
+			expected: expected{node: &Node{Name: "traefik"}},
+		},
+		{
 			desc: "map with non string key",
 			element: struct {
 				Foo struct {

--- a/parser/nodes_metadata.go
+++ b/parser/nodes_metadata.go
@@ -77,12 +77,14 @@ func (m metadata) add(rootType reflect.Type, node *Node) error {
 
 	if fType.Kind() == reflect.Struct || fType.Kind() == reflect.Ptr && fType.Elem().Kind() == reflect.Struct ||
 		fType.Kind() == reflect.Map {
-		if len(node.Children) == 0 && field.Tag.Get(m.TagName) != TagLabelAllowEmpty {
+		if len(node.Children) == 0 && !(field.Tag.Get(m.TagName) == TagLabelAllowEmpty || field.Tag.Get(m.TagName) == "-") {
 			return fmt.Errorf("%s cannot be a standalone element (type %s)", node.Name, fType)
 		}
 
 		node.Disabled = len(node.Value) > 0 && !strings.EqualFold(node.Value, "true") && field.Tag.Get(m.TagName) == TagLabelAllowEmpty
 	}
+
+	node.Disabled = node.Disabled || field.Tag.Get(m.TagName) == "-"
 
 	if len(node.Children) == 0 {
 		return nil

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -17,6 +17,15 @@ type Potato struct {
 	Meta map[string]map[string]interface{}
 }
 
+type Ignored struct {
+	String  string                 `label:"-"`
+	StringP *string                `label:"-"`
+	Struct  Tomato                 `label:"-"`
+	StructP *Tomato                `label:"-"`
+	Slice   []string               `label:"-"`
+	Map     map[string]interface{} `label:"-"`
+}
+
 func TestDecode_RawValue(t *testing.T) {
 	testCases := []struct {
 		desc     string
@@ -328,13 +337,49 @@ func TestDecode_RawValue(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc: "Ignore label tag, one element label for each type",
+			elt:  &Ignored{},
+			labels: map[string]string{
+				"traefik.string":       "test1",
+				"traefik.stringp":      "test1",
+				"traefik.struct.name":  "test1",
+				"traefik.structp.name": "test1",
+				"traefik.slice":        "test1",
+				"traefik.map.aaa":      "test1",
+			},
+			expected: &Ignored{
+				String:  "",
+				StringP: nil,
+				Struct:  Tomato{},
+				StructP: nil,
+				Slice:   nil,
+				Map:     nil,
+			},
+		},
+		{
+			desc: "Ignore label tag, one empty label for each type",
+			elt:  &Ignored{},
+			labels: map[string]string{
+				"traefik.string":  "",
+				"traefik.stringp": "",
+				"traefik.struct":  "",
+				"traefik.structp": "",
+				"traefik.slice":   "",
+				"traefik.map":     "",
+			},
+			expected: &Ignored{
+				String:  "",
+				StringP: nil,
+				Struct:  Tomato{},
+				StructP: nil,
+				Slice:   nil,
+				Map:     nil,
+			},
+		},
 	}
 
 	for _, test := range testCases {
-		if test.desc != "level 3" {
-			continue
-		}
-
 		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			err := Decode(test.labels, test.elt, "traefik")

--- a/parser/tags.go
+++ b/parser/tags.go
@@ -2,12 +2,14 @@ package parser
 
 const (
 	// TagLabel allows to apply a custom behavior.
-	// - "allowEmpty": allows to create an empty struct.
+	// - "allowEmpty": allows the creation of a type that is supposed to have children
+	// (i.e: struct, pointer of struct, and map), without any children.
 	// - "-": ignore the field.
 	TagLabel = "label"
 
 	// TagFile allows to apply a custom behavior.
-	// - "allowEmpty": allows to create an empty struct.
+	// - "allowEmpty": allows the creation of a type that is supposed to have children
+	// (i.e: struct, pointer of struct, and map), without any children.
 	// - "-": ignore the field.
 	TagFile = "file"
 


### PR DESCRIPTION
This PR fixes the behavior for the ignore tag.

The first commit adds new test cases, that are not related to the changes in this PR. 

It also adds documentation about tag usage.

Co-authored-by: Mathieu Lonjaret <mathieu.lonjaret@gmail.com>