### PR TITLE
fix: allow decoding of nested raw typed slices

### DIFF
--- a/file/file_test.go
+++ b/file/file_test.go
@@ -326,12 +326,12 @@ bar:
       - 42
 `
 
-	element := &map[string]interface{}{}
+	element := map[string]interface{}{}
 
-	err := DecodeContent(content, ".yaml", element)
+	err := DecodeContent(content, ".yaml", &element)
 	require.NoError(t, err)
 
-	expected := &map[string]interface{}{
+	expected := map[string]interface{}{
 		"foo": []interface{}{"foo", "bar"},
 		"bar": map[string]interface{}{
 			"foo": []interface{}{"foo", "bar"},

--- a/file/file_test.go
+++ b/file/file_test.go
@@ -190,45 +190,6 @@ yi: {}
 	assert.Equal(t, expected, element)
 }
 
-func TestDecodeTypedSliceRecursive_YAML(t *testing.T) {
-	content := `
-foo:
-  - foo
-  - bar
-bar:
-  foo:
-  - foo
-  - bar
-  baz:
-    foo:
-    - foo
-    - bar
-    boz:
-      foo:
-      - 42
-      - 42
-`
-
-	element := &map[string]interface{}{}
-
-	err := DecodeContent(content, ".yaml", element)
-	require.NoError(t, err)
-
-	expected := &map[string]interface{}{
-		"foo": []interface{}{"foo", "bar"},
-		"bar": map[string]interface{}{
-			"foo": []interface{}{"foo", "bar"},
-			"baz": map[string]interface{}{
-				"foo": []interface{}{"foo", "bar"},
-				"boz": map[string]interface{}{
-					"foo": []interface{}{int64(42), int64(42)},
-				},
-			},
-		},
-	}
-	assert.Equal(t, expected, element)
-}
-
 func TestDecodeContent_YAML_rawSlice(t *testing.T) {
 	content := `
 testData:
@@ -344,6 +305,45 @@ meta:
 			assert.Equal(t, test.expected, element)
 		})
 	}
+}
+
+func TestDecodeContent_YAML_typedSliceRecursive(t *testing.T) {
+	content := `
+foo:
+  - foo
+  - bar
+bar:
+  foo:
+  - foo
+  - bar
+  baz:
+    foo:
+    - foo
+    - bar
+    boz:
+      foo:
+      - 42
+      - 42
+`
+
+	element := &map[string]interface{}{}
+
+	err := DecodeContent(content, ".yaml", element)
+	require.NoError(t, err)
+
+	expected := &map[string]interface{}{
+		"foo": []interface{}{"foo", "bar"},
+		"bar": map[string]interface{}{
+			"foo": []interface{}{"foo", "bar"},
+			"baz": map[string]interface{}{
+				"foo": []interface{}{"foo", "bar"},
+				"boz": map[string]interface{}{
+					"foo": []interface{}{int64(42), int64(42)},
+				},
+			},
+		},
+	}
+	assert.Equal(t, expected, element)
 }
 
 func TestDecodeContent_JSON(t *testing.T) {

--- a/file/file_test.go
+++ b/file/file_test.go
@@ -190,6 +190,45 @@ yi: {}
 	assert.Equal(t, expected, element)
 }
 
+func TestDecodeTypedSliceRecursive_YAML(t *testing.T) {
+	content := `
+foo:
+  - foo
+  - bar
+bar:
+  foo:
+  - foo
+  - bar
+  baz:
+    foo:
+    - foo
+    - bar
+    boz:
+      foo:
+      - 42
+      - 42
+`
+
+	element := &map[string]interface{}{}
+
+	err := DecodeContent(content, ".yaml", element)
+	require.NoError(t, err)
+
+	expected := &map[string]interface{}{
+		"foo": []interface{}{"foo", "bar"},
+		"bar": map[string]interface{}{
+			"foo": []interface{}{"foo", "bar"},
+			"baz": map[string]interface{}{
+				"foo": []interface{}{"foo", "bar"},
+				"boz": map[string]interface{}{
+					"foo": []interface{}{int64(42), int64(42)},
+				},
+			},
+		},
+	}
+	assert.Equal(t, expected, element)
+}
+
 func TestDecodeContent_YAML_rawSlice(t *testing.T) {
 	content := `
 testData:

--- a/parser/element_fill.go
+++ b/parser/element_fill.go
@@ -420,15 +420,10 @@ func (f filler) fillRawValue(field reflect.Value, node *Node, subMap bool) error
 		return nil
 	}
 
-	// In the case of submap, fill raw typed slices recursively.
-	mapRawValue := reflect.ValueOf(node.RawValue)
-	for k, v := range m {
-		value, err := f.fillRawTypedSliceRecursive(v)
-		if err != nil {
-			return err
-		}
-
-		mapRawValue.SetMapIndex(reflect.ValueOf(k), value)
+	// In the case of sub-map, fill raw typed slices recursively.
+	_, err := f.fillRawMapWithTypedSlice(m)
+	if err != nil {
+		return err
 	}
 
 	p := map[string]interface{}{node.Name: m}
@@ -439,8 +434,7 @@ func (f filler) fillRawValue(field reflect.Value, node *Node, subMap bool) error
 	return nil
 }
 
-// fillRawTypedSliceRecursive is used to fill raw typed slices recursively.
-func (f filler) fillRawTypedSliceRecursive(elt interface{}) (reflect.Value, error) {
+func (f filler) fillRawMapWithTypedSlice(elt interface{}) (reflect.Value, error) {
 	eltValue := reflect.ValueOf(elt)
 
 	switch eltValue.Kind() {
@@ -456,7 +450,7 @@ func (f filler) fillRawTypedSliceRecursive(elt interface{}) (reflect.Value, erro
 
 	case reflect.Map:
 		for k, v := range elt.(map[string]interface{}) {
-			value, err := f.fillRawTypedSliceRecursive(v)
+			value, err := f.fillRawMapWithTypedSlice(v)
 			if err != nil {
 				return eltValue, err
 			}

--- a/parser/element_fill_test.go
+++ b/parser/element_fill_test.go
@@ -1556,6 +1556,48 @@ func TestFill(t *testing.T) {
 				},
 			}},
 		},
+		{
+			desc:              "recursive slices",
+			rawSliceSeparator: "║",
+			node: &Node{
+				Name: "traefik",
+				Kind: reflect.Pointer,
+				Children: []*Node{
+					{
+						Name: "bar",
+						RawValue: map[string]interface{}{
+							"baz": map[string]interface{}{
+								"boz": map[string]interface{}{
+									"foo": "║2║42║42",
+								},
+								"foo": "║24║foo║bar",
+							},
+							"foo": "║24║foo║bar",
+						},
+					},
+					{
+						Name:  "foo",
+						Value: "║24║foo║bar",
+						RawValue: map[string]interface{}{
+							"foo": "║24║foo║bar",
+						},
+					},
+				},
+			},
+			element: &map[string]interface{}{},
+			expected: expected{element: &map[string]interface{}{
+				"foo": []interface{}{"foo", "bar"},
+				"bar": map[string]interface{}{
+					"foo": []interface{}{"foo", "bar"},
+					"baz": map[string]interface{}{
+						"foo": []interface{}{"foo", "bar"},
+						"boz": map[string]interface{}{
+							"foo": []interface{}{int64(42), int64(42)},
+						},
+					},
+				},
+			}},
+		},
 	}
 
 	for _, test := range testCases {


### PR DESCRIPTION
### What does this PR do?

This PR is adding the decoding of raw typed slices in nested structs.

### Motivation

Fixing https://github.com/traefik/traefik/issues/9638