### PR TITLE
feat: handles any with RawValue

### DIFF
--- a/parser/element_fill.go
+++ b/parser/element_fill.go
@@ -103,6 +103,8 @@ func (f filler) fill(field reflect.Value, node *Node) error {
 		return f.setMap(field, node)
 	case reflect.Slice:
 		return f.setSlice(field, node)
+	case reflect.Interface:
+		return f.setInterface(field, node)
 	default:
 		return nil
 	}
@@ -575,4 +577,14 @@ func (f filler) cleanRawValue(value reflect.Value) (reflect.Value, error) {
 	}
 
 	return value, nil
+}
+
+func (f filler) setInterface(field reflect.Value, node *Node) error {
+	if node.RawValue != nil {
+		field.Set(reflect.ValueOf(node.RawValue))
+		return nil
+	}
+
+	field.Set(reflect.ValueOf(node.Value))
+	return nil
 }

--- a/parser/element_fill_test.go
+++ b/parser/element_fill_test.go
@@ -1598,6 +1598,56 @@ func TestFill(t *testing.T) {
 				},
 			}},
 		},
+		{
+			desc: "any",
+			node: &Node{
+				Name: "traefik",
+				Kind: reflect.Struct,
+				Children: []*Node{
+					{
+						Name:      "bar",
+						FieldName: "Bar",
+						RawValue: map[string]interface{}{
+							"baz": map[string]interface{}{
+								"boz": map[string]interface{}{
+									"foo": "42",
+								},
+								"foo": "bar",
+							},
+							"foo": "bar",
+						},
+					},
+					{
+						Name:      "foo",
+						FieldName: "Foo",
+						Value:     "bar",
+						RawValue: map[string]interface{}{
+							"foo": "bar",
+						},
+					},
+
+					{
+						Name:      "fii",
+						FieldName: "Fii",
+						Value:     "bar",
+					},
+				},
+			},
+			element: &struct {
+				Bar any
+				Foo any
+				Fii any
+			}{},
+			expected: expected{element: &struct {
+				Bar any
+				Foo any
+				Fii any
+			}{
+				Bar: map[string]any{"foo": "bar", "baz": map[string]any{"foo": "bar", "boz": map[string]any{"foo": "42"}}},
+				Foo: map[string]any{"foo": "bar"},
+				Fii: "bar",
+			}},
+		},
 	}
 
 	for _, test := range testCases {

--- a/parser/nodes_metadata.go
+++ b/parser/nodes_metadata.go
@@ -129,6 +129,11 @@ func (m metadata) add(rootType reflect.Type, node *Node) error {
 		return nil
 	}
 
+	if fType.Kind() == reflect.Interface {
+		addRawValue(node)
+		return nil
+	}
+
 	return fmt.Errorf("invalid node %s: %v", node.Name, fType.Kind())
 }
 

--- a/parser/nodes_metadata_test.go
+++ b/parser/nodes_metadata_test.go
@@ -121,7 +121,42 @@ func TestAddMetadata(t *testing.T) {
 				},
 			},
 			structure: struct{ Foo interf }{},
-			expected:  expected{error: true},
+			expected: expected{
+				node: &Node{
+					Name: "traefik",
+					Kind: reflect.Struct,
+					Children: []*Node{
+						{Name: "Foo", FieldName: "Foo", RawValue: map[string]any{
+							"Fii": "hii",
+						}, Kind: reflect.Interface},
+					},
+				},
+			},
+		},
+		{
+			desc: "level 1, interface multiple level",
+			tree: &Node{
+				Name: "traefik",
+				Children: []*Node{
+					{Name: "Foo", Value: "", Children: []*Node{
+						{Name: "Fii", Children: []*Node{
+							{Name: "Fuu", Value: "huu"},
+						}},
+					}},
+				},
+			},
+			structure: struct{ Foo interf }{},
+			expected: expected{
+				node: &Node{
+					Name: "traefik",
+					Kind: reflect.Struct,
+					Children: []*Node{
+						{Name: "Foo", FieldName: "Foo", RawValue: map[string]any{
+							"Fii": map[string]any{"Fuu": "huu"},
+						}, Kind: reflect.Interface},
+					},
+				},
+			},
 		},
 		{
 			desc: "level 1, map string",


### PR DESCRIPTION
This PR handles field any as RawValue.

it means that if you have for example something like
```
"foo.bar.baz"="fuu"
"foo.bar.huu"="hii"
```
and you try to handle it with a struct like
```golang
struct {
  foo any
}
```

This will do something like this:
```golang
{
   foo: map[string]any{
      "bar": map[string]any{
         "baz": "fuu",
         "huu": "hii",
      } 
   }
}
```