### PR TITLE
feat: make env prefix allow underscores

### DIFF
--- a/env/env.go
+++ b/env/env.go
@@ -69,7 +69,7 @@ func Encode(prefix string, element interface{}) ([]parser.Flat, error) {
 }
 
 func checkPrefix(prefix string) error {
-	prefixPattern := `^[a-zA-Z0-9]+_$`
+	prefixPattern := `^[a-zA-Z0-9][a-zA-Z0-9_]*_$`
 	matched, err := regexp.MatchString(prefixPattern, prefix)
 	if err != nil {
 		return err


### PR DESCRIPTION
### What?

Previously the env prefix could only consist of an alphanumeric string followed by an underscore.
I changed to pattern to allow the prefix to have an underscore in it, but not start with an underscore.

### Why?

I currently have a root command, `server`, which uses paerser for all the configuration since I really like the way traefik is configured. The root command loads from env with a `SERVER_` prefix.
Now I am adding a health check subcommand, `server healthcheck`, which will run the health check on the server. I also use paerser for this subcommand, but with a different configuration altogether. And now I wanted to use a `SERVER_HEALTHCHECK_` prefix for this subcommand to keep the two seperate, but I got the error that the prefix was invalid...