### PR TITLE
Adjust parsing of flags when the output is a generic map[string]string

### DIFF
--- a/flag/flag_test.go
+++ b/flag/flag_test.go
@@ -151,6 +151,51 @@ func TestDecode(t *testing.T) {
 			},
 		},
 		{
+			desc: "map string with '.' in key",
+			args: []string{"--foo.name.value=bar"},
+			element: &struct {
+				Foo map[string]string
+			}{},
+			expected: &struct {
+				Foo map[string]string
+			}{
+				Foo: map[string]string{
+					"name.value": "bar",
+				},
+			},
+		},
+		{
+			desc: "map string with '.' in key and multiple entries",
+			args: []string{"--foo.name.value=bar", "--foo.name.value2=bar2"},
+			element: &struct {
+				Foo map[string]string
+			}{},
+			expected: &struct {
+				Foo map[string]string
+			}{
+				Foo: map[string]string{
+					"name.value":  "bar",
+					"name.value2": "bar2",
+				},
+			},
+		},
+		{
+			desc: "map string with '.' in key and multiple mixed entries",
+			args: []string{"--foo.name.value=bar", "--foo.name.value2=bar2", "--foo.name2=bar3"},
+			element: &struct {
+				Foo map[string]string
+			}{},
+			expected: &struct {
+				Foo map[string]string
+			}{
+				Foo: map[string]string{
+					"name.value":  "bar",
+					"name.value2": "bar2",
+					"name2":       "bar3",
+				},
+			},
+		},
+		{
 			desc: "map struct",
 			args: []string{"--foo.name.value=bar"},
 			element: &struct {

--- a/flag/flagparser_test.go
+++ b/flag/flagparser_test.go
@@ -132,6 +132,39 @@ func TestParse(t *testing.T) {
 			},
 		},
 		{
+			desc: "map string with '.' in key",
+			args: []string{"--foo.name.value=bar"},
+			element: &struct {
+				Foo map[string]string
+			}{},
+			expected: map[string]string{
+				"traefik.foo.name.value": "bar",
+			},
+		},
+		{
+			desc: "map string with '.' in key and multiple entries",
+			args: []string{"--foo.name.value=bar", "--foo.name2.value2=baz"},
+			element: &struct {
+				Foo map[string]string
+			}{},
+			expected: map[string]string{
+				"traefik.foo.name.value":   "bar",
+				"traefik.foo.name2.value2": "baz",
+			},
+		},
+		{
+			desc: "map string with '.' in key and multiple mixed entries",
+			args: []string{"--foo.name.value=bar", "--foo.name2.value2=baz", "--foo.name3=bay"},
+			element: &struct {
+				Foo map[string]string
+			}{},
+			expected: map[string]string{
+				"traefik.foo.name.value":   "bar",
+				"traefik.foo.name2.value2": "baz",
+				"traefik.foo.name3":        "bay",
+			},
+		},
+		{
 			desc: "map struct",
 			args: []string{"--foo.name.value=bar"},
 			element: &struct {

--- a/parser/element_fill.go
+++ b/parser/element_fill.go
@@ -325,11 +325,7 @@ func (f filler) setMap(field reflect.Value, node *Node) error {
 
 	if field.Type().Elem().Kind() == reflect.String {
 		for _, child := range node.Children {
-			if len(child.Children) > 0 {
-				f.fillRecursively(child.Name, child, field)
-			} else {
-				field.SetMapIndex(reflect.ValueOf(child.Name), reflect.ValueOf(child.Value))
-			}
+			f.fillRecursively(child.Name, child, field)
 		}
 
 		return nil

--- a/parser/element_fill.go
+++ b/parser/element_fill.go
@@ -330,7 +330,6 @@ func (f filler) setMap(field reflect.Value, node *Node) error {
 			} else {
 				field.SetMapIndex(reflect.ValueOf(child.Name), reflect.ValueOf(child.Value))
 			}
-
 		}
 
 		return nil

--- a/parser/element_fill.go
+++ b/parser/element_fill.go
@@ -291,6 +291,17 @@ func (f filler) setSliceAsStruct(field reflect.Value, node *Node) error {
 	return nil
 }
 
+func (f filler) fillRecursively(parent string, node *Node, field reflect.Value) {
+	if len(node.Children) == 0 {
+		field.SetMapIndex(reflect.ValueOf(parent), reflect.ValueOf(node.Value))
+		return
+	}
+
+	for _, child := range node.Children {
+		f.fillRecursively(parent+"."+child.Name, child, field)
+	}
+}
+
 func (f filler) setMap(field reflect.Value, node *Node) error {
 	if field.IsNil() {
 		field.Set(reflect.MakeMap(field.Type()))
@@ -307,6 +318,19 @@ func (f filler) setMap(field reflect.Value, node *Node) error {
 			if err != nil {
 				return err
 			}
+		}
+
+		return nil
+	}
+
+	if field.Type().Elem().Kind() == reflect.String {
+		for _, child := range node.Children {
+			if len(child.Children) > 0 {
+				f.fillRecursively(child.Name, child, field)
+			} else {
+				field.SetMapIndex(reflect.ValueOf(child.Name), reflect.ValueOf(child.Value))
+			}
+
 		}
 
 		return nil

--- a/parser/element_fill_test.go
+++ b/parser/element_fill_test.go
@@ -693,6 +693,97 @@ func TestFill(t *testing.T) {
 			},
 		},
 		{
+			desc: "map string with key containing '.'",
+			node: &Node{
+				Name: "traefik",
+				Kind: reflect.Struct,
+				Children: []*Node{
+					{
+						Name:      "Foo",
+						FieldName: "Foo",
+						Kind:      reflect.Map,
+						Children: []*Node{
+							{Name: "name", Kind: reflect.Map, Children: []*Node{{Name: "value", Value: "hii", Kind: reflect.String}}},
+						},
+					},
+				},
+			},
+			element: &struct {
+				Foo map[string]string
+			}{},
+			expected: expected{
+				element: &struct {
+					Foo map[string]string
+				}{
+					Foo: map[string]string{
+						"name.value": "hii",
+					},
+				},
+			},
+		},
+		{
+			desc: "map string with keys containing '.' and multiple entries",
+			node: &Node{
+				Name: "traefik",
+				Kind: reflect.Struct,
+				Children: []*Node{
+					{
+						Name:      "Foo",
+						FieldName: "Foo",
+						Kind:      reflect.Map,
+						Children: []*Node{
+							{Name: "name1", Kind: reflect.Map, Children: []*Node{{Name: "value", Value: "hii", Kind: reflect.String}, {Name: "value2", Value: "hii", Kind: reflect.String}}},
+						},
+					},
+				},
+			},
+			element: &struct {
+				Foo map[string]string
+			}{},
+			expected: expected{
+				element: &struct {
+					Foo map[string]string
+				}{
+					Foo: map[string]string{
+						"name1.value":  "hii",
+						"name1.value2": "hii",
+					},
+				},
+			},
+		},
+		{
+			desc: "map string with keys containing '.' and multiple mixed entries",
+			node: &Node{
+				Name: "traefik",
+				Kind: reflect.Struct,
+				Children: []*Node{
+					{
+						Name:      "Foo",
+						FieldName: "Foo",
+						Kind:      reflect.Map,
+						Children: []*Node{
+							{Name: "name1", Kind: reflect.Map, Children: []*Node{{Name: "value", Value: "hii", Kind: reflect.String}, {Name: "value2", Value: "hii", Kind: reflect.String}}},
+							{Name: "name2", Kind: reflect.String, Value: "hii"},
+						},
+					},
+				},
+			},
+			element: &struct {
+				Foo map[string]string
+			}{},
+			expected: expected{
+				element: &struct {
+					Foo map[string]string
+				}{
+					Foo: map[string]string{
+						"name1.value":  "hii",
+						"name1.value2": "hii",
+						"name2":        "hii",
+					},
+				},
+			},
+		},
+		{
 			desc: "map struct",
 			node: &Node{
 				Name: "traefik",


### PR DESCRIPTION
# What does this PR do?

With the current parsing is not possible to set values to a field map[string]string in which the key contains `.`.

## Motivation

For example: using the flags `--tracing.resourceAttributes.service.environment=test`, currently the value is mapped like `service=` instead of `service.environment=test`.

## More
- [x] Added test cases